### PR TITLE
Allow parsing of replays with anonymized data

### DIFF
--- a/rep/rep.go
+++ b/rep/rep.go
@@ -156,14 +156,22 @@ func newRep(m *mpq.MPQ, game, message, tracker bool) (parsedRep *Rep, errRes err
 	rep.protocol = p
 
 	data, err := m.FileByHash(620083690, 3548627612, 4013960850) // "replay.details"
-	if err != nil {
-		return nil, ErrInvalidRepFile
+	if err != nil || data == nil || len(data) == 0 {
+		// Attempt to open the anonymized version
+		data, err = m.FileByName("replay.details.backup")
+		if err != nil || data == nil || len(data) == 0 {
+			return nil, ErrInvalidRepFile
+		}
 	}
 	rep.Details = Details{Struct: p.DecodeDetails(data)}
 
 	data, err = m.FileByHash(3544165653, 1518242780, 4280631132) // "replay.initData"
-	if err != nil {
-		return nil, ErrInvalidRepFile
+	if err != nil || data == nil || len(data) == 0 {
+		// Attempt to open the anonymized version
+		data, err = m.FileByName("replay.initData.backup")
+		if err != nil || data == nil || len(data) == 0 {
+			return nil, ErrInvalidRepFile
+		}
 	}
 	rep.InitData = NewInitData(p.DecodeInitData(data))
 


### PR DESCRIPTION
The parser was failing on special replay files that contains anonymized versions of the replay details and init data