### PR TITLE
fix (*Event).UserID()

### DIFF
--- a/types.go
+++ b/types.go
@@ -309,7 +309,8 @@ func (e *Event) Loop() int64 {
 
 // UserID returns the ID of the user that issued the event.
 func (e *Event) UserID() int64 {
-	return e.Int("userid")
+	v := e.Structv("userid")
+	return (&v).Int("userId")
 }
 
 // BitArr is a bit array which stores the bits in a byte slice.

--- a/types.go
+++ b/types.go
@@ -309,8 +309,7 @@ func (e *Event) Loop() int64 {
 
 // UserID returns the ID of the user that issued the event.
 func (e *Event) UserID() int64 {
-	v := e.Structv("userid")
-	return (&v).Int("userId")
+    return e.Int("userid", "userId")
 }
 
 // BitArr is a bit array which stores the bits in a byte slice.


### PR DESCRIPTION
`(*Event).UserID()` always returned `0`.

It should be something like `evt[userid][userId]` not `evt[userid]`.

This is how a game event looks:
```
{
  "data": "",
  "id": 11,
  "loop": 0,
  "name": "BankKey",
  "type": 7,
  "userid": {
    "userId": 1
  }
}
```