### PR TITLE
fix (*Protocol).decodeEvts(), Event.Name

### DIFF
--- a/build/78285.go
+++ b/build/78285.go
@@ -1,0 +1,5 @@
+package build
+
+func init() {
+	Duplicates[78285] = 77379
+}

--- a/protocol.go
+++ b/protocol.go
@@ -446,7 +446,7 @@ func (p *Protocol) decodeEvts(d decoder, evtidTypeid int, etypes []EvtType, decU
 		e := Event{Struct: d.instance(evtType.typeid).(Struct), EvtType: evtType}
 		// Copy to / duplicate data in Struct so Struct.String() includes them too
 		e.Struct["id"] = evtid
-		e.Struct["name"] = evtType.Name
+		e.Struct["evtTypeName"] = evtType.Name
 		e.Struct["loop"] = loop
 		if decUserID {
 			e.Struct["userid"] = userid


### PR DESCRIPTION
https://github.com/Blizzard/s2protocol/blob/master/s2protocol/versions/protocol15405.py
```
    ('_struct',[[('m_name',13,-5)]]),  #55
    ('_blob',[(0,6)]),  #56
    ('_struct',[[('m_name',56,-5)]]),  #57
    ('_struct',[[('m_name',56,-7),('m_type',5,-6),('m_data',13,-5)]]),  #58
    ('_struct',[[('m_type',5,-7),('m_name',56,-6),('m_data',25,-5)]]),  #59
```

I just found a small issue. There are events that uses the name `name`. I guess it should be prevented from being overwritten? Thank you for reviewing my pull request. 

I was looking through game events and I expected to get an event like this:
```
{
  "data": "GGGGGGGG",
  "id": 11,
  "loop": 0,
  "name": "48",
  "type": 6,
  "userid": {
    "userId": 1
  }
}
```

But I got this one:

```
{
  "data": "GGGGGGGG",
  "id": 11,
  "loop": 0,
  "name": "BankKey",
  "type": 6,
  "userid": {
    "userId": 1
  }
}
```

This PR changes the result to:
```
{
  "data": "GGGGGGGG",
  "evtTypeName": "BankKey",
  "id": 11,
  "loop": 0,
  "name": "48",
  "type": 6,
  "userid": {
    "userId": 1
  }
}
```

