### PR TITLE
Mark 87702 as duplicate of 80949

### DIFF
--- a/build/87702.go
+++ b/build/87702.go
@@ -1,0 +1,5 @@
+package build
+
+func init() {
+	Duplicates[87702] = 80949
+}


### PR DESCRIPTION
SC2 was patched on 3/15/2022.

Game updated from/to:

- 5.0.8.86383
- 5.0.9.87702

This was the first balance patch in 1 year, 7 months [1]. And the first patch since Microsoft bought Blizzard.

[1] - https://liquipedia.net/starcraft2/Patches